### PR TITLE
Updated CraftPresence to ATM3-Remix

### DIFF
--- a/overrides/config/craftpresence.cfg
+++ b/overrides/config/craftpresence.cfg
@@ -66,15 +66,15 @@
 
 "Customize Server Messages" {
     # Server Icon to default to when in an Unsupported Server [default: default]
-    S:"Default Server Icon"=allthemods3
+    S:"Default Server Icon"=allthemods3remix
 
     # Server MOTD to default to, in the case of a null MOTD 
     #  (And in Direct Connects) [default: A Minecraft Server]
-    S:"Default Server MOTD"=An All The Mods 3 Server
+    S:"Default Server MOTD"=An All The Mods 3 - Remix Server
 
     # Server Display Name to default to, in the case of a null Name 
     #  (And in Direct Connects) [default: Minecraft Server]
-    S:"Default Server Name"=All The Mods 3 Server
+    S:"Default Server Name"=All The Mods 3 - Remix Server
 
     # Server Messages Data 
     #  (Format: server_IP;message;icon or default;message;icon) 
@@ -91,17 +91,17 @@
 "Customize Status Messages" {
     # Message to Display when joining a LAN Game 
     #  (Will only show if Status is Enabled) [default: Playing on a LAN Server]
-    S:"LAN Game Message"=Playing on a All The Mods 3 LAN Server
+    S:"LAN Game Message"=Playing on a All The Mods 3 - Remix 3 LAN Server
 
     # Message to Display when Loading the Game [default: Loading the Game]
-    S:"Loading Message"=Loading All The Mods 3
+    S:"Loading Message"=Loading All The Mods 3 - Remix
 
     # Message to Display when on the Main Menu [default: In the Main Menu]
-    S:"Main Menu Message"=Main Menu in All The Mods 3
+    S:"Main Menu Message"=Main Menu in All The Mods 3 - Remix
 
     # Message to Display while in Singleplayer 
     #  (Will only show if Status is Enabled) [default: Playing Singleplayer]
-    S:"Singleplayer Game Message"=Playing Singleplayer All The Mods 3
+    S:"Singleplayer Game Message"=Playing Singleplayer All The Mods 3 - Remix
 }
 
 
@@ -111,7 +111,7 @@
 
     # Default Icon 
     #  (Used in Main Menu or Dimensions and Servers) [default: grass]
-    S:"Default Icon"=allthemods3
+    S:"Default Icon"=allthemods3remix
     B:"Deteck Technic Pack"=true
 
     # Enable Detection for Twitch/Curse Manifest Data? [default: true]


### PR DESCRIPTION
The config of CraftPresence is still in the ATM3 (Outdated) and this make the Discord users think that a player is playing ATM3 but is actually playing ATM3Remix.